### PR TITLE
team_grouper and new features

### DIFF
--- a/team_grouper/team_grouper/team_grouper.py
+++ b/team_grouper/team_grouper/team_grouper.py
@@ -1,43 +1,106 @@
-from typing import List, Tuple
-import random
 import argparse
+import csv
+import random
+from typing import List, Tuple, Dict
 
-def group_names(names: List[Tuple[str, str, str]], num_groups: int) -> List[List[Tuple[str, str, str]]]:
-    random.shuffle(names)
-    groups = [[] for _ in range(num_groups)]
-    for i, name in enumerate(names):
-        groups[i % num_groups].append(name)
+Person = Tuple[str, str, str, str]  # (Name, Team, Role, Location)
+
+
+def read_people_from_file(filepath: str) -> List[Person]:
+    """Read people from a CSV file with columns: Name,Team,Role,Location"""
+    people: List[Person] = []
+    with open(filepath, newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            name = row["Name"].strip()
+            team = row["Team"].strip()
+            role = row["Role"].strip()
+            location = row["Location"].strip().lower()
+            people.append((name, team, role, location))
+    return people
+
+
+def group_balanced(people: List[Person], num_groups: int) -> List[List[Person]]:
+    """
+    Distribute people into groups:
+    - Try to ensure each group has at least one of each role (if possible)
+    - Keep groups roughly even in size
+    - Spread same teams across groups as much as possible
+    """
+    if num_groups <= 0:
+        raise ValueError("Number of groups must be positive")
+
+    random.shuffle(people)
+    groups: List[List[Person]] = [[] for _ in range(num_groups)]
+
+    # Track counts
+    team_counts: List[Dict[str, int]] = [dict() for _ in range(num_groups)]
+    role_counts: List[Dict[str, int]] = [dict() for _ in range(num_groups)]
+
+    # Group people by role
+    role_buckets: Dict[str, List[Person]] = {}
+    for person in people:
+        _, _, role, _ = person
+        role_buckets.setdefault(role, []).append(person)
+
+    # --- Pass 1: Distribute role by role, keeping group sizes balanced ---
+    for role, bucket in role_buckets.items():
+        random.shuffle(bucket)
+        for person in bucket:
+            # Pick the group with the fewest people so far,
+            # break ties by minimizing team/role collisions
+            best_group = min(
+                range(num_groups),
+                key=lambda g: (
+                    len(groups[g]),
+                    team_counts[g].get(person[1], 0),
+                    role_counts[g].get(role, 0),
+                ),
+            )
+            groups[best_group].append(person)
+            team_counts[best_group][person[1]] = team_counts[best_group].get(person[1], 0) + 1
+            role_counts[best_group][role] = role_counts[best_group].get(role, 0) + 1
+
     return groups
 
 def main():
-    parser = argparse.ArgumentParser(description="Group names into teams.")
+    parser = argparse.ArgumentParser(description="Group names into balanced teams.")
     parser.add_argument("num_remote_groups", type=int, help="Number of groups for remote names.")
     parser.add_argument("num_office_groups", type=int, help="Number of groups for office names.")
-    parser.add_argument("names_teams_locations", nargs="+", help="Names, their teams, and locations in the format 'Name,Team,Location'.")
+    parser.add_argument("--file", required=True, help="Path to CSV file containing Name,Team,Role,Location")
 
     args = parser.parse_args()
 
-    num_remote_groups = args.num_remote_groups
-    num_office_groups = args.num_office_groups
-    names_teams_locations = args.names_teams_locations
+    people = read_people_from_file(args.file)
 
-    names = [tuple(ntl.split(",")) for ntl in names_teams_locations]
+    remote_people = [p for p in people if p[3] == "remote"]
+    office_people = [p for p in people if p[3] == "office"]
 
-    remote_names = [name for name in names if name[2] == "remote"]
-    office_names = [name for name in names if name[2] == "office"]
+    role_priority = {
+        "PO": 0,
+        "DL": 1,
+        "TL": 2,
+        "BA": 3,
+        "UR": 4,
+        "Engineer": 5,
+    }
 
-    remote_groups = group_names(remote_names, num_remote_groups)
-    office_groups = group_names(office_names, num_office_groups)
+    if remote_people:
+        remote_groups = group_balanced(remote_people, args.num_remote_groups)
+        print("Remote Groups:")
+        for i, group in enumerate(remote_groups, 1):
+            sorted_group = sorted(group, key=lambda x: role_priority.get(x[2], 999))
+            formatted = [f"{name} ({team}, {role})" for name, team, role, _ in sorted_group]
+            print(f"Group {i}: {', '.join(formatted)}")
 
-    print("Remote Groups:")
-    for i, group in enumerate(remote_groups, 1):
-        formatted_group = [(name, team) for name, team, _ in group]
-        print(f"Group {i}: {formatted_group}")
+    if office_people:
+        office_groups = group_balanced(office_people, args.num_office_groups)
+        print("\nOffice Groups:")
+        for i, group in enumerate(office_groups, 1):
+            sorted_group = sorted(group, key=lambda x: role_priority.get(x[2], 999))
+            formatted = [f"\n{name} ({team}, {role})" for name, team, role, _ in sorted_group]
+            print(f"\nGroup {i}: {', '.join(formatted)}")
 
-    print("\nOffice Groups:")
-    for i, group in enumerate(office_groups, 1):
-        formatted_group = [(name, team) for name, team, _ in group]
-        print(f"Group {i}: {formatted_group}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Distribute people into groups:
    - Try to ensure each group has at least one of each role (if possible)
    - Keep groups roughly even in size
    - Spread same teams across groups as much as possible
- orders the group lists by role.